### PR TITLE
Add rdkitPath and rdkitWorkerPath props

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@
 Initialises a web worker with `RDKitModule` instance from [@rdkit/rdkit](https://github.com/rdkit/rdkit-js) and exposes it via a react context
 
 ## Setup
+
 #### Assets
+
+The project using this package needs to provide it with [RDKit package assets](https://github.com/rdkit/rdkit/tree/master/Code/MinimalLib#using-the-rdkit-package-assets)
+
 After installing [@rdkit/rdkit](https://github.com/rdkit/rdkit-js) copy to your public folder
 `node_modules/@iktos-oss/rdkit-provider/lib/rdkit-worker.js`
-`node_modules/@rdkit/rdkit/dist/RDKit_minimal.js` 
+`node_modules/@rdkit/rdkit/dist/RDKit_minimal.js`
 `node_modules/@rdkit/rdkit/dist/RDKit_minimal.wasm`
 
 ## Usage
@@ -21,6 +25,7 @@ import { RDKitProvider } from '@iktos/rdkit-provider';
 ```
 
 you can also enable caching for molecule, which would enhance performance
+
 ```html
 import { RDKitProvider } from '@iktos/rdkit-provider';
 <RDKitProvider cache={{ enableJsMolCaching: true, maxJsMolsCached: 50 }}>
@@ -28,14 +33,16 @@ import { RDKitProvider } from '@iktos/rdkit-provider';
 </RDKitProvider>
 ```
 
-Options that can be passed to  ```RDKitProvider ```:
+Options that can be passed to `RDKitProvider `:
 
-| prop  | type | functionality | required/optional |
-| ------------- | ------------- | ------------- | ------------- |
-| cache  | ```RDKitProviderCacheOptions = { enableJsMolCaching?: boolean; maxJsMolsCached?: number; }```  | enables ```JSMol``` caching for better performance | optional  |
-| preferCoordgen  | ```boolean```  | will be passed to [@rdkit/rdkitjs prefer_coordgen](https://docs.rdkitjs.com/interfaces/RDKitModule.html#prefer_coordgen.prefer_coordgen-1) to use Schrodinger’s open-source Coordgen library to generate 2D coordinates of molecules | optional  |  
-| removeHs  | ```boolean```  |  toggles removing hydrogens molecules. Defaults to true | optional  |  
-| ```initialRdkitInstance```  | ```RDKitModule``` from ```@rdkit/rdkitjs``` | pass an instance of to expose by the context `RDKitModule`, if not passed rdkit-provider creates one for you  | optional  |
+| prop                    | type                                                                                      | functionality                                                                                                                                                                                                                        | required/optional |
+| ----------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
+| cache                   | `RDKitProviderCacheOptions = { enableJsMolCaching?: boolean; maxJsMolsCached?: number; }` | enables `JSMol` caching for better performance                                                                                                                                                                                       | optional          |
+| preferCoordgen          | `boolean`                                                                                 | will be passed to [@rdkit/rdkitjs prefer_coordgen](https://docs.rdkitjs.com/interfaces/RDKitModule.html#prefer_coordgen.prefer_coordgen-1) to use Schrodinger’s open-source Coordgen library to generate 2D coordinates of molecules | optional          |
+| removeHs                | `boolean`                                                                                 | toggles removing hydrogens molecules. Defaults to true                                                                                                                                                                               | optional          |
+| `initialWorkerInstance` | `Worker` instance of `rdkit-worker.js`                                                    | pass an rdkit worker instance, if not passed rdkit-provider creates one for you                                                                                                                                                      | optional          |
+| `rdkitPath`             | `string` default to `/RDKit_minimal.js` in `initRDKit.ts`                                 | pass a custom path to rdkit module                                                                                                                                                                                                   | optional          |
+| `rdkitWorkerPath`       | `string` default to `/rdkit-worker.js` in `instanciate.ts`                                | pass a custom path to to rdkit worker                                                                                                                                                                                                | optional          |
 
 You can make use of a set of helper functions exposed by the package
 
@@ -47,17 +54,15 @@ const Component = () => {
   const { isValidSmiles } = useRDKitUtils();
   const submit = useCallback(
     async (smiles) => {
-    const { isValid } = await isValidSmiles({smiles});
+      const { isValid } = await isValidSmiles({ smiles });
       if (!isValid) return;
       // ...
     },
     [isValidSmiles],
   );
-  
-  if (!worker) return 'loading ...'
-  return <>
-    ...
-  </>
+
+  if (!worker) return 'loading ...';
+  return <>...</>;
   //...
 };
 ```

--- a/src/contexts/RDKitContext.tsx
+++ b/src/contexts/RDKitContext.tsx
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
   MIT License
 
   Copyright (c) 2023 Iktos
@@ -33,8 +33,11 @@ export interface RDKitContextValue {
 
 export type RDKitProviderProps = PropsWithChildren<{
   cache?: RDKitProviderCacheOptions;
+  initialWorkerInstance?: Worker;
   preferCoordgen?: boolean;
   removeHs?: boolean;
+  rdkitPath?: string;
+  rdkitWorkerPath?: string;
 }>;
 
 // force default context to be undefined, to check if package users have wrapped it with the required provider
@@ -43,24 +46,29 @@ export const RDKitContext = React.createContext<RDKitContextValue>(undefined as 
 
 export const RDKitProvider: React.FC<RDKitProviderProps> = ({
   cache = {},
+  initialWorkerInstance = null,
   preferCoordgen = false,
   removeHs = true,
+  rdkitPath,
+  rdkitWorkerPath,
   children,
 }) => {
   const [worker, setWorker] = useState<Worker | null>(null);
 
   useEffect(() => {
     let isProviderMounted = true;
-    let workerInstance: Worker | null = null;
+    let workerInstance: Worker | null = initialWorkerInstance;
 
     const initialise = async () => {
-      workerInstance = initWorker();
+      if (!workerInstance) workerInstance = initWorker(rdkitWorkerPath);
+
       // await rdkit module init in worker before starting using the worker
       await postWorkerJob(workerInstance, {
         actionType: RDKIT_WORKER_ACTIONS.INIT_RDKIT_MODULE,
         key: 'worker-init',
-        payload: { cache, preferCoordgen, removeHs },
+        payload: { rdkitPath, cache, preferCoordgen, removeHs },
       });
+
       if (isProviderMounted && workerInstance) {
         setWorker(workerInstance);
       }
@@ -76,7 +84,7 @@ export const RDKitProvider: React.FC<RDKitProviderProps> = ({
         key: 'worker-terminate',
       });
     };
-  }, [cache, preferCoordgen, removeHs]);
+  }, [initialWorkerInstance, cache, preferCoordgen, rdkitPath, rdkitWorkerPath, removeHs]);
 
   return <RDKitContext.Provider value={{ worker }}>{children}</RDKitContext.Provider>;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
   MIT License
 
   Copyright (c) 2023 Iktos
@@ -26,3 +26,4 @@ export * from './contexts';
 export * from './hooks';
 export * from './consumer';
 export * from './types';
+export * from './worker';

--- a/src/worker/actions.ts
+++ b/src/worker/actions.ts
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
   MIT License
 
   Copyright (c) 2023 Iktos
@@ -57,7 +57,7 @@ export type WorkerMessageNarrower =
   | {
       actionType: 'INIT_RDKIT_MODULE';
       key: string;
-      payload: { cache: RDKitProviderCacheOptions; preferCoordgen: boolean; removeHs: boolean };
+      payload: { rdkitPath?: string; cache: RDKitProviderCacheOptions; preferCoordgen: boolean; removeHs: boolean };
     }
   | {
       actionType: 'GET_SVG';

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
   MIT License
 
   Copyright (c) 2023 Iktos
@@ -24,3 +24,4 @@
 
 export * from './instanciate';
 export * from './utils';
+export { RDKIT_WORKER_ACTIONS } from './actions';

--- a/src/worker/instanciate.ts
+++ b/src/worker/instanciate.ts
@@ -24,8 +24,9 @@
 
 import { broadcastLocalResponse } from './utils/broadcast';
 
-export const initWorker = () => {
-  const worker = new Worker(new URL(`${globalThis.origin}/rdkit-worker.js`));
+export const initWorker = (rdkitWorkerPath?: string) => {
+  const path = rdkitWorkerPath || '/rdkit-worker.js';
+  const worker = new Worker(new URL(path, globalThis.origin));
   worker.onmessage = broadcastLocalResponse;
   return worker;
 };

--- a/src/worker/utils/initRDKit.ts
+++ b/src/worker/utils/initRDKit.ts
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
   MIT License
 
   Copyright (c) 2023 Iktos
@@ -25,16 +25,19 @@
 import { MAX_CACHED_JSMOLS } from '../../constants';
 import { RDKitProviderCacheOptions } from '../../contexts';
 
-export const initRdkit = async ({ preferCoordgen, removeHs, cache = {} }: InitWorkerOptions) => {
+export const initRdkit = async ({ rdkitPath, preferCoordgen, removeHs, cache = {} }: InitWorkerOptions) => {
   if (cache) {
     initWorkerCache({ cache, removeHs });
   }
+
+  if (globalThis.workerRDKit) return;
+
+  const path = rdkitPath || '/RDKit_minimal.js';
+  const url = new URL(path, globalThis.origin);
   //@ts-ignore
-  importScripts(`${globalThis.origin}/RDKit_minimal.js`);
+  importScripts(url);
   if (!globalThis.initRDKitModule) return;
-  await globalThis.initRDKitModule().then((rdkitModule) => {
-    globalThis.workerRDKit = rdkitModule;
-  });
+  globalThis.workerRDKit = await globalThis.initRDKitModule();
   globalThis.workerRDKit.prefer_coordgen(preferCoordgen);
 };
 
@@ -54,4 +57,5 @@ interface InitWorkerOptions {
   preferCoordgen: boolean;
   removeHs: boolean;
   cache?: RDKitProviderCacheOptions;
+  rdkitPath?: string;
 }


### PR DESCRIPTION
Added a custom worker path props ~and revert the change for initialRdkitInstance in v2~

EDIT:
It seems we can't pass an rdkit instance in postmessage worker (Can't be cloned). So I removed this change and this PR will only focus on adding a custom rdkit worker path props.

EDIT 2:
Added custom rdkitPath props