### PR TITLE
fix: use query molecule for getCanonicalSmarts to avoid invalid mol

### DIFF
--- a/src/consumer/actions.ts
+++ b/src/consumer/actions.ts
@@ -64,12 +64,15 @@ export const getMoleculeDetails = (worker: Worker, { smiles }: { smiles: string 
   }).then((msg) => msg.payload as PayloadResponseType<'GET_MOLECULE_DETAILS'>);
 };
 
-export const getCanonicalFormForStructure = (worker: Worker, { structure }: { structure: string }) => {
+export const getCanonicalFormForStructure = (
+  worker: Worker,
+  { structure, molNotation, useQMol }: { structure: string; molNotation?: MolNotation; useQMol?: boolean },
+) => {
   const key = structure;
   return postWorkerJob(worker, {
     actionType: RDKIT_WORKER_ACTIONS.GET_CANONICAL_FORM_FOR_STRUCTURE,
     key: key,
-    payload: { structure },
+    payload: { structure, molNotation, useQMol },
   }).then((msg) => msg.payload as PayloadResponseType<'GET_CANONICAL_FORM_FOR_STRUCTURE'>);
 };
 

--- a/src/worker/actions.ts
+++ b/src/worker/actions.ts
@@ -82,7 +82,7 @@ export type WorkerMessageNarrower =
   | {
       actionType: 'GET_CANONICAL_FORM_FOR_STRUCTURE';
       key: string;
-      payload: { structure: string };
+      payload: { structure: string; molNotation?: MolNotation; useQMol?: boolean };
     }
   | {
       actionType: 'IS_VALID_SMILES';

--- a/src/worker/utils/caching.ts
+++ b/src/worker/utils/caching.ts
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
   MIT License
 
   Copyright (c) 2023 Iktos
@@ -24,36 +24,41 @@
 
 import { JSMol } from '@rdkit/rdkit';
 
-export const storeJSMolInCache = (smiles: string, mol: JSMol) => {
+/**
+ * Store JSMol object in global jsMolCache
+ * @param structure can be a smiles, smarts or molblock...
+ * @param jsMol can be a mol or qmol
+ */
+export const storeJSMolInCache = (structure: string, jsMol: JSMol) => {
   if (!globalThis.rdkitWorkerGlobals.jsMolCacheEnabled || !globalThis.rdkitWorkerGlobals.jsMolCache) return;
   const nbCachedMolecules = Object.keys(globalThis.rdkitWorkerGlobals.jsMolCache).length;
   if (nbCachedMolecules > globalThis.rdkitWorkerGlobals.maxJsMolsCached) {
     cleanJSMolCache();
-    globalThis.rdkitWorkerGlobals.jsMolCache = { [smiles]: mol };
+    globalThis.rdkitWorkerGlobals.jsMolCache = { [structure]: jsMol };
     return;
   }
   try {
-    globalThis.rdkitWorkerGlobals.jsMolCache[smiles] = mol;
+    globalThis.rdkitWorkerGlobals.jsMolCache[structure] = jsMol;
   } catch (e) {
     console.error(e);
     cleanJSMolCache();
-    globalThis.rdkitWorkerGlobals.jsMolCache = { [smiles]: mol };
+    globalThis.rdkitWorkerGlobals.jsMolCache = { [structure]: jsMol };
   }
 };
 
-export const getJSMolFromCache = (smiles: string) => {
+export const getJSMolFromCache = (structure: string) => {
   if (!globalThis.rdkitWorkerGlobals.jsMolCacheEnabled || !globalThis.rdkitWorkerGlobals.jsMolCache) {
     return null;
   }
-  return globalThis.rdkitWorkerGlobals.jsMolCache[smiles];
+  return globalThis.rdkitWorkerGlobals.jsMolCache[structure];
 };
 
 export const cleanJSMolCache = () => {
   if (!globalThis.rdkitWorkerGlobals?.jsMolCache) return;
-  for (const [smiles, mol] of Object.entries(globalThis.rdkitWorkerGlobals.jsMolCache)) {
+  for (const [structure, mol] of Object.entries(globalThis.rdkitWorkerGlobals.jsMolCache)) {
     try {
       mol.delete();
-      delete globalThis.rdkitWorkerGlobals.jsMolCache[smiles];
+      delete globalThis.rdkitWorkerGlobals.jsMolCache[structure];
     } catch {
       // multiple cleanJSMolCache could be called in the same time, => avoid calling delete on the same mol
     }

--- a/src/worker/utils/molecule.ts
+++ b/src/worker/utils/molecule.ts
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
   MIT License
 
   Copyright (c) 2023 Iktos
@@ -44,6 +44,26 @@ export const get_molecule = (smiles: string, RDKit: RDKitModule) => {
     console.error(e);
     cleanJSMolCache();
     return get_molecule_memory_unsafe(smiles, RDKit);
+  }
+};
+
+const get_query_molecule_memory_unsafe = (structure: string, RDKit: RDKitModule) => {
+  const cachedQMolecule = getJSMolFromCache(structure);
+  if (cachedQMolecule) return cachedQMolecule;
+  if (!structure) return null;
+  if (!RDKit) return null;
+  const qmol = RDKit.get_qmol(structure);
+  storeJSMolInCache(structure, qmol);
+  return qmol;
+};
+
+export const get_query_molecule = (structure: string, RDKit: RDKitModule) => {
+  try {
+    return get_query_molecule_memory_unsafe(structure, RDKit);
+  } catch (e) {
+    console.error(e);
+    cleanJSMolCache();
+    return get_query_molecule_memory_unsafe(structure, RDKit);
   }
 };
 

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -57,7 +57,7 @@ addEventListener('message', async ({ data }: { data: WorkerMessage }) => {
       break;
     case RDKIT_WORKER_ACTIONS.GET_CANONICAL_FORM_FOR_STRUCTURE:
       responsePayload = {
-        canonicalForm: getCanonicalFormForStructure(data.payload.structure),
+        canonicalForm: getCanonicalFormForStructure(data.payload),
       } satisfies PayloadResponseType<'GET_CANONICAL_FORM_FOR_STRUCTURE'>;
       break;
     case RDKIT_WORKER_ACTIONS.GET_SVG:


### PR DESCRIPTION
`getCanonicalSmarts` is using `get_mol` behind. It doesn't work for certain structure, like this smarts `[OX1]=CN`.

Changes:
- changed `getCanonicalFormForStructure` to use `convertMolNotation` behind by adding `molNotation` and `useQMol` params
 - added a separate cache for qmols. ~~It's not used here when drawing smarts, but I added it just in case.~~
 - Removed `getCanonicalSmarts/Smiles` methods, `convertMolNotation` does the same thing