### PR TITLE
Missing release_molecule and use qmol for getMatchingSubstructure

### DIFF
--- a/src/worker/utils/chem.ts
+++ b/src/worker/utils/chem.ts
@@ -131,7 +131,7 @@ export const hasMatchingSubstructure = ({ smiles, substructure }: { smiles: stri
 
 export const getMatchingSubstructure = ({ structure, substructure }: { structure: string; substructure: string }) => {
   const mol = get_molecule(structure, globalThis.workerRDKit);
-  const molToMach = get_molecule(substructure, globalThis.workerRDKit);
+  const molToMach = get_query_molecule(substructure, globalThis.workerRDKit);
   if (!mol || !molToMach) return null;
   const { atoms, bonds } = JSON.parse(mol.get_substruct_match(molToMach)) as { atoms: number[]; bonds: number[] };
   release_molecule(mol);

--- a/src/worker/utils/chem.ts
+++ b/src/worker/utils/chem.ts
@@ -62,7 +62,7 @@ export const getSvgFromSmarts = ({ smarts, width, height }: { smarts: string; wi
   if (!smartsMol) return null;
 
   const svg = smartsMol.get_svg(width, height);
-  smartsMol.delete();
+  release_molecule(smartsMol);
   return svg;
 };
 
@@ -109,9 +109,7 @@ export const isValidSmarts = (smarts: string): boolean => {
   if (!mol) return false;
 
   const isValid = mol.is_valid();
-  if (!globalThis.rdkitWorkerGlobals.jsMolCacheEnabled) {
-    mol.delete();
-  }
+  release_molecule(mol);
   return isValid;
 };
 

--- a/src/worker/utils/molecule.ts
+++ b/src/worker/utils/molecule.ts
@@ -91,9 +91,7 @@ export const get_molecule_details = ({ smiles }: GetMoleculeDetailsParams, RDKit
   const mol = get_molecule(smiles, RDKit);
   if (!mol) return null;
   const details = JSON.parse(mol.get_descriptors());
-  if (!globalThis.rdkitWorkerGlobals.jsMolCacheEnabled) {
-    mol.delete();
-  }
+  release_molecule(mol);
 
   return {
     numAtoms: details.NumHeavyAtoms,


### PR DESCRIPTION
Should use `release_molecule` instead of `.delete()`, if possible.

Also changed `getMatchingSubstructure`: we should use query mol for the substructure.